### PR TITLE
feat: enhance poker ui with timers and effects

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 // src/App.js
-import React, { useCallback, useEffect } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 import usePokerEngine from "./hooks/usePokerEngine";
 import PokerTable from "./components/PokerTable";
 import ActionBar from "./components/ActionBar";
@@ -22,8 +22,11 @@ export default function App() {
   ]);
 
   const playDeal = useSound("/sounds/card.mp3");
-  const playAction = useSound("/sounds/action.mp3");
+  const playFx = useSound("/sounds/minecraft_level_up.mp3");
   const playWin = useSound("/sounds/win.mp3");
+
+  const prevCommunity = useRef(state.community.length);
+  const prevPot = useRef(pot);
 
   useEffect(() => {
     if (state.round === "Preflop" && state.community.length === 0) {
@@ -37,32 +40,43 @@ export default function App() {
     }
   }, [status, playWin]);
 
+  useEffect(() => {
+    if (prevCommunity.current < state.community.length && state.community.length > 0) {
+      playFx();
+    }
+    prevCommunity.current = state.community.length;
+  }, [state.community.length, playFx]);
+
+  useEffect(() => {
+    if (prevPot.current !== pot) {
+      playFx();
+      prevPot.current = pot;
+    }
+  }, [pot, playFx]);
+
   const handleAction = useCallback(
     (action, amount) => {
-      playAction();
       rawHandleAction(action, amount);
     },
-    [rawHandleAction, playAction]
+    [rawHandleAction]
   );
 
   return (
-    <div style={{ minHeight: "100vh", background: "#1c0f14" }}>
-      <div style={{ maxWidth: 1100, margin: "0 auto", padding: 16 }}>
-        <h1 style={{ color: "white", marginBottom: 8 }}>Pyker (React)</h1>
-        <div style={{ color: "#ddd", marginBottom: 8 }}>
+    <div className="min-h-screen">
+      <div className="max-w-4xl mx-auto p-4">
+        <h1 className="text-white mb-2">Pyker (React)</h1>
+        <div className="text-gray-200 mb-2">
           Status: <b>{status}</b>
         </div>
 
         <PokerTable state={state} pot={pot} winners={winners} />
 
-        {/* Hanya tampilkan action bar kalau giliran kamu dan game belum showdown */}
         {state.currentPlayer === 0 &&
           status === "playing" &&
           !state.players[0].folded && (
             <ActionBar actions={availableActions} onAction={handleAction} />
           )}
 
-        {/* Tombol New Hand saat showdown/ended */}
         {status !== "playing" && winners.length > 0 && (
           <WinnerModal
             winners={winners.map((i) => state.players[i].name)}
@@ -70,18 +84,6 @@ export default function App() {
           />
         )}
       </div>
-
-      <style>{`
-        .btn {
-          padding: 10px 14px;
-          border-radius: 10px;
-          border: none;
-          background: #8f1d2c;
-          color: white;
-          cursor: pointer;
-        }
-        .btn:hover { filter: brightness(1.1); }
-      `}</style>
     </div>
   );
 }

--- a/src/components/ActionBar.jsx
+++ b/src/components/ActionBar.jsx
@@ -12,21 +12,28 @@ export default function ActionBar({ actions, onAction }) {
   const fold = actions.find((a) => a.type === "fold");
 
   return (
-    <div
-      style={{ marginTop: 16, display: "flex", gap: 8, alignItems: "center" }}
-    >
+    <div className="mt-4 flex gap-2 items-center">
       {fold && (
-        <button onClick={() => onAction("fold")} className="btn">
+        <button
+          onClick={() => onAction("fold")}
+          className="px-4 py-2 bg-red-600 hover:bg-red-700 rounded-lg shadow transition transform hover:scale-105"
+        >
           Fold
         </button>
       )}
       {check && (
-        <button onClick={() => onAction("check")} className="btn">
+        <button
+          onClick={() => onAction("check")}
+          className="px-4 py-2 bg-green-600 hover:bg-green-700 rounded-lg shadow transition transform hover:scale-105"
+        >
           Check
         </button>
       )}
       {call && (
-        <button onClick={() => onAction("call")} className="btn">
+        <button
+          onClick={() => onAction("call")}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-700 rounded-lg shadow transition transform hover:scale-105"
+        >
           Call {call.amount}
         </button>
       )}
@@ -38,24 +45,16 @@ export default function ActionBar({ actions, onAction }) {
             min={hasBet.min ?? 1}
             max={hasBet.max ?? 9999}
             onChange={(e) => setAmount(parseInt(e.target.value || "0", 10))}
-            style={{ width: 90, padding: 6 }}
+            className="w-24 p-1 rounded text-black"
           />
-          <button onClick={() => onAction("bet", amount)} className="btn">
+          <button
+            onClick={() => onAction("bet", amount)}
+            className="px-4 py-2 bg-purple-600 hover:bg-purple-700 rounded-lg shadow transition transform hover:scale-105"
+          >
             {check ? "Bet" : "Raise"}
           </button>
         </>
       )}
-      <style>{`
-        .btn {
-          padding: 8px 12px;
-          border-radius: 8px;
-          border: none;
-          background: #8f1d2c;
-          color: white;
-          cursor: pointer;
-        }
-        .btn:hover { filter: brightness(1.1); }
-      `}</style>
     </div>
   );
 }

--- a/src/components/ActionPanel.js
+++ b/src/components/ActionPanel.js
@@ -30,7 +30,7 @@ export default function ActionPanel({
                 />
                 <button
                   onClick={() => handleAction(act, betAmount, range)}
-                  className="px-4 py-2 bg-blue-600 rounded-lg hover:bg-blue-700"
+                  className="px-4 py-2 bg-blue-600 rounded-lg hover:bg-blue-700 shadow transition transform hover:scale-105"
                 >
                   Bet/Raise
                 </button>
@@ -42,7 +42,7 @@ export default function ActionPanel({
             <button
               key={idx}
               onClick={() => handleAction(action)}
-              className={`px-4 py-2 rounded-lg ${
+              className={`px-4 py-2 rounded-lg shadow transition transform hover:scale-105 ${
                 action === Action.Fold
                   ? "bg-red-600 hover:bg-red-700"
                   : "bg-green-600 hover:bg-green-700"

--- a/src/components/CardImg.jsx
+++ b/src/components/CardImg.jsx
@@ -17,7 +17,12 @@ export default function CardImg({ card, w = 72 }) {
       transition={{ duration: 0.3 }}
       src={imgSrc(card)}
       alt={card?.back ? "Back" : `${card?.rank ?? "?"}${card?.suit ?? ""}`}
-      style={{ width: w, height: "auto", borderRadius: 8 }}
+      style={{
+        width: w,
+        height: "auto",
+        borderRadius: 8,
+        border: "2px solid white",
+      }}
     />
   );
 }

--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -1,22 +1,41 @@
 // src/components/PlayerSeat.jsx
-import React from "react";
+import React, { useEffect, useState } from "react";
 import CardImg from "./CardImg";
+import { getHandName } from "../core/handEvaluator";
 
 export default function PlayerSeat({
   player,
+  community = [],
   isYou = false,
   isTurn = false,
   reveal = false,
 }) {
   const showFace = isYou || reveal;
   const [c1, c2] = player.hand || [];
+  const [timeLeft, setTimeLeft] = useState(30);
+
+  useEffect(() => {
+    if (!isTurn) {
+      setTimeLeft(30);
+      return;
+    }
+    setTimeLeft(30);
+    const id = setInterval(() => {
+      setTimeLeft((t) => (t > 0 ? t - 1 : 0));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [isTurn]);
+
+  const comboName = showFace
+    ? getHandName(player.hand || [], community || [])
+    : "";
   return (
     <div
       style={{
         padding: 12,
         minWidth: 220,
         borderRadius: 12,
-        background: isTurn ? "#2d2a" : "#222a",
+        background: isTurn ? "#ffffff22" : "#222a",
         color: "white",
         boxShadow: isTurn ? "0 0 0 2px #ffd54f inset" : "none",
       }}
@@ -31,6 +50,10 @@ export default function PlayerSeat({
         <CardImg card={showFace ? c1 : { back: true }} />
         <CardImg card={showFace ? c2 : { back: true }} />
       </div>
+      {showFace && (
+        <div style={{ marginTop: 4, fontSize: 12 }}>{comboName}</div>
+      )}
+      <div style={{ marginTop: 4, fontSize: 12 }}>Time left: {timeLeft}s</div>
     </div>
   );
 }

--- a/src/components/PokerTable.jsx
+++ b/src/components/PokerTable.jsx
@@ -11,7 +11,7 @@ export default function PokerTable({ state, pot, winners }) {
 
   return (
     <div className="p-4 text-white">
-      <div className="relative mx-auto max-w-4xl bg-green-800 rounded-full p-8 shadow-inner">
+      <div className="relative mx-auto max-w-4xl border-2 border-white rounded-lg p-8 bg-white/10">
         <div className="flex justify-between">
           <div>
             Round: <b>{round}</b>
@@ -29,11 +29,15 @@ export default function PokerTable({ state, pot, winners }) {
         </div>
 
         {/* Players grid */}
-        <div className="grid gap-3" style={{ gridTemplateColumns: "repeat(auto-fit, minmax(230px,1fr))" }}>
+        <div
+          className="grid gap-3"
+          style={{ gridTemplateColumns: "repeat(auto-fit, minmax(230px,1fr))" }}
+        >
           {players.map((p, i) => (
             <PlayerSeat
               key={i}
               player={p}
+              community={community}
               isYou={i === 0}
               isTurn={i === currentPlayer && round !== "Showdown" && !p.folded}
               reveal={revealEveryone}

--- a/src/core/handEvaluator.js
+++ b/src/core/handEvaluator.js
@@ -113,6 +113,30 @@ export function evaluateHandPublic(cards) {
   return handRank(cards.map(toInternal));
 }
 
+const handNames = [
+  "High Card",
+  "One Pair",
+  "Two Pair",
+  "Three of a Kind",
+  "Straight",
+  "Flush",
+  "Full House",
+  "Four of a Kind",
+  "Straight Flush",
+];
+
+export function getHandName(hand, community) {
+  const all = [...hand, ...community];
+  if (all.length < 5) return "";
+  const combos = combinations(all, 5);
+  let best = null;
+  for (const combo of combos) {
+    const rank = handRank(combo.map(toInternal));
+    if (!best || compareHands(rank, best) > 0) best = rank;
+  }
+  return handNames[best.rankValue];
+}
+
 export function getWinners(players, community) {
   const communityCards = community.map(toInternal);
   let bestRank = null;

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,18 @@
 @tailwind components;
 @tailwind utilities;
 
+@font-face {
+  font-family: "Monocraft";
+  src: url("/fonts/Monocraft.ttf") format("truetype"),
+    url("/fonts/Monocraft.otf") format("opentype");
+  font-weight: normal;
+  font-style: normal;
+}
+
 body {
-  @apply bg-green-900 text-white font-sans;
+  @apply text-white;
+  font-family: "Monocraft", monospace;
+  background-image: url("/assets/background.jpg");
+  background-size: cover;
+  background-position: center;
 }


### PR DESCRIPTION
## Summary
- add countdown timers and hand combination info for each seat
- apply Monocraft font with new background and card/table styling
- play level-up sound on bets and community card reveals

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68abea80180c8322aeec02f4d5a4a616