### PR TITLE
Improve sound handling, bot timer, and UI

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -22,7 +22,7 @@ export default function App() {
   ]);
 
   // Menggunakan suara yang sama untuk semua aksi
-  const playActionSound = useSound("/public/sounds/minecraft_level_up.mp3");
+  const playSound = useSound("/public/sounds/minecraft_level_up.mp3");
 
   const prevCommunity = useRef(state.community.length);
   const prevPot = useRef(pot);
@@ -30,16 +30,16 @@ export default function App() {
   // Menggunakan suara saat Preflop
   useEffect(() => {
     if (state.round === "Preflop" && state.community.length === 0) {
-      playActionSound();
+      playSound();
     }
-  }, [state.round, state.community.length, playActionSound]);
+  }, [state.round, state.community.length, playSound]);
 
   // Menggunakan suara saat Showdown
   useEffect(() => {
     if (status === "showdown") {
-      playActionSound();
+      playSound();
     }
-  }, [status, playActionSound]);
+  }, [status, playSound]);
 
   // Menggunakan suara saat ada perubahan kartu komunitas
   useEffect(() => {
@@ -47,28 +47,28 @@ export default function App() {
       prevCommunity.current < state.community.length &&
       state.community.length > 0
     ) {
-      playActionSound();
+      playSound();
     }
     prevCommunity.current = state.community.length;
-  }, [state.community.length, playActionSound]);
+  }, [state.community.length, playSound]);
 
   // Menggunakan suara saat pot berubah
   useEffect(() => {
     if (prevPot.current !== pot) {
-      playActionSound();
+      playSound();
       prevPot.current = pot;
     }
-  }, [pot, playActionSound]);
+  }, [pot, playSound]);
 
-  // Menambahkan suara untuk tindakan (bet, raise, call)
+  // Menambahkan suara untuk tindakan (bet, raise, call, fold, check)
   const handleAction = useCallback(
     (action, amount) => {
-      if (["bet", "raise", "call"].includes(action)) {
-        playActionSound();
+      if (["bet", "raise", "call", "fold", "check"].includes(action)) {
+        playSound();
       }
       rawHandleAction(action, amount);
     },
-    [rawHandleAction, playActionSound]
+    [rawHandleAction, playSound]
   );
 
   return (

--- a/src/components/ActionBar.jsx
+++ b/src/components/ActionBar.jsx
@@ -4,12 +4,12 @@ import React, { useState } from "react";
 export default function ActionBar({ actions, onAction }) {
   const [amount, setAmount] = useState(10);
 
-  const renderImgBtn = (src, alt, handler) => (
+  const renderBtn = (label, handler, color) => (
     <button
       onClick={handler}
-      className="transition-transform hover:scale-105 focus:outline-none"
+      className={`px-4 py-2 rounded text-white font-semibold shadow-md transition-transform hover:scale-105 ${color}`}
     >
-      <img src={src} alt={alt} className="h-12 w-auto" />
+      {label}
     </button>
   );
 
@@ -21,24 +21,14 @@ export default function ActionBar({ actions, onAction }) {
   const fold = actions.find((a) => a.type === "fold");
 
   return (
-    <div className="mt-4 flex gap-3 items-center">
-      {fold &&
-        renderImgBtn("/assets/buttons/fold.png", "Fold", () => onAction("fold"))}
+    <div className="mt-4 flex flex-wrap gap-3 items-center justify-center">
+      {fold && renderBtn("Fold", () => onAction("fold"), "bg-red-600 hover:bg-red-700")}
 
-      {check &&
-        renderImgBtn(
-          "/assets/buttons/check.png",
-          "Check",
-          () => onAction("check")
-        )}
+      {check && renderBtn("Check", () => onAction("check"), "bg-gray-600 hover:bg-gray-700")}
 
       {call && (
         <div className="flex flex-col items-center">
-          {renderImgBtn(
-            "/assets/buttons/call.png",
-            "Call",
-            () => onAction("call")
-          )}
+          {renderBtn("Call", () => onAction("call"), "bg-green-600 hover:bg-green-700")}
           <span className="text-xs mt-1">Call {call.amount}</span>
         </div>
       )}
@@ -53,10 +43,10 @@ export default function ActionBar({ actions, onAction }) {
             onChange={(e) => setAmount(parseInt(e.target.value || "0", 10))}
             className="w-24 p-1 rounded text-black"
           />
-          {renderImgBtn(
-            check ? "/assets/buttons/bet.png" : "/assets/buttons/raise.png",
+          {renderBtn(
             check ? "Bet" : "Raise",
-            () => onAction("bet", amount)
+            () => onAction("bet", amount),
+            "bg-blue-600 hover:bg-blue-700"
           )}
         </>
       )}

--- a/src/components/PlayerSeat.jsx
+++ b/src/components/PlayerSeat.jsx
@@ -33,48 +33,32 @@ export default function PlayerSeat({
     : "";
   return (
     <div
-      style={{
-        padding: 12,
-        minWidth: 220,
-        borderRadius: 12,
-        background: isTurn ? "#ffffff22" : "#222a",
-        color: "white",
-        boxShadow: isTurn ? "0 0 0 2px #ffd54f inset" : "none",
-      }}
+      className={`p-3 min-w-[220px] rounded-xl text-white ${
+        isTurn ? "bg-white/10 ring-2 ring-amber-300" : "bg-black/40"
+      }`}
     >
-      <div style={{ fontWeight: 700 }}>
+      <div className="font-bold">
         {player.name} {player.folded ? "(Fold)" : ""}
       </div>
-      <div style={{ fontSize: 12, opacity: 0.85 }}>
+      <div className="text-xs opacity-80">
         Chips: {player.chips} &nbsp; • &nbsp; Bet: {player.bet}
       </div>
-      <div style={{ marginTop: 6, display: "flex", gap: 6 }}>
+      <div className="mt-2 flex gap-2">
         <CardImg card={showFace ? c1 : { back: true }} />
         <CardImg card={showFace ? c2 : { back: true }} />
       </div>
       {showFace && (
-        <div style={{ marginTop: 4, fontSize: 12, textAlign: "center" }}>
-          {comboName}
-        </div>
+        <div className="mt-1 text-xs text-center">{comboName}</div>
       )}
-      <div style={{ marginTop: 8 }}>
-        <div
-          style={{
-            height: 8,
-            background: "#ffffff44",
-            borderRadius: 4,
-            overflow: "hidden",
-          }}
-        >
+      <div className="mt-3">
+        <div className="h-2 bg-white/30 rounded overflow-hidden">
           <motion.div
             animate={{ width: `${(timeLeft / MAX_TIME) * 100}%` }}
             transition={{ ease: "linear", duration: 1 }}
-            style={{ height: "100%", background: "#ffd54f" }}
+            className="h-full bg-amber-300"
           />
         </div>
-        <div style={{ marginTop: 4, fontSize: 12, textAlign: "center" }}>
-          {timeLeft}s
-        </div>
+        <div className="mt-1 text-xs text-center">{timeLeft}s</div>
       </div>
     </div>
   );

--- a/src/components/PokerTable.jsx
+++ b/src/components/PokerTable.jsx
@@ -11,18 +11,23 @@ export default function PokerTable({ state, pot, winners }) {
 
   return (
     <div className="p-4 text-white">
-      <div className="relative mx-auto max-w-4xl border-2 border-white rounded-lg p-8 bg-black/40 backdrop-blur-sm">
-        <div className="flex justify-between">
+      <div className="relative mx-auto max-w-4xl border border-gray-600 rounded-xl p-8 bg-gray-900/70 backdrop-blur-sm shadow-lg">
+        <div className="flex justify-between text-sm md:text-base">
           <div>
             Round: <b>{round}</b>
           </div>
-          <motion.div key={pot} initial={{ scale: 0.8 }} animate={{ scale: 1 }} className="text-lg">
+          <motion.div
+            key={pot}
+            initial={{ scale: 0.8 }}
+            animate={{ scale: 1 }}
+            className="text-lg font-semibold"
+          >
             Pot: <b>{pot}</b>
           </motion.div>
         </div>
 
         {/* Community cards */}
-        <div className="flex gap-2 justify-center my-4">
+        <div className="flex gap-2 justify-center my-6">
           {[0, 1, 2, 3, 4].map((i) => (
             <CardImg key={i} card={community[i]} w={88} />
           ))}

--- a/src/hooks/usePokerEngine.js
+++ b/src/hooks/usePokerEngine.js
@@ -26,13 +26,20 @@ export default function usePokerEngine(initialPlayers) {
     const current = state.players[state.currentPlayer];
     if (!current?.isBot) return;
 
-    const bot = new AIBot(game, state, {
-      push: ({ action, amount }) => {
-        setState((prev) => game.applyAction(prev, action, amount));
+    const bot = new AIBot(
+      game,
+      state,
+      {
+        push: ({ action, amount }) => {
+          setState((prev) => game.applyAction(prev, action, amount));
+        },
       },
-    }, current.level || "easy");
+      current.level || "easy"
+    );
 
-    const t = setTimeout(() => bot.run(), 700);
+    const delayMap = { easy: 1200, normal: 2000, hard: 3000 };
+    const thinkTime = delayMap[current.level] || 1500;
+    const t = setTimeout(() => bot.run(), thinkTime);
     return () => clearTimeout(t);
   }, [state, status, game]);
 


### PR DESCRIPTION
## Summary
- unify all game sounds into one reusable hook and trigger for fold and check
- slow bot decisions based on difficulty for more realistic timers
- replace image buttons with styled HTML buttons and refresh table/player layout

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68abfba3747483229cbd47bd7acb1c8e