### PR TITLE
Enhance Texas Hold'em flow and AI

### DIFF
--- a/src/core/ai.js
+++ b/src/core/ai.js
@@ -1,5 +1,39 @@
 // src/core/ai.js
-import { evaluateHandPublic, toInternal } from "./handEvaluator";
+import { getWinners } from "./handEvaluator";
+
+function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+}
+
+function estimateWinRate(state, playerIndex, simulations = 200) {
+  const hero = state.players[playerIndex];
+  const opponents = state.players.filter(
+    (_, i) => i !== playerIndex && !state.players[i].folded
+  );
+  if (opponents.length === 0) return 1;
+
+  let wins = 0;
+  let ties = 0;
+
+  for (let s = 0; s < simulations; s++) {
+    const deck = [...state.deck];
+    const community = [...state.community];
+    shuffle(deck);
+    while (community.length < 5) community.push(deck.pop());
+    const simPlayers = [{ hand: hero.hand }];
+    for (let i = 0; i < opponents.length; i++) {
+      simPlayers.push({ hand: [deck.pop(), deck.pop()] });
+    }
+    const winners = getWinners(simPlayers, community);
+    if (winners.length === 1 && winners[0] === simPlayers[0]) wins++;
+    else if (winners.includes(simPlayers[0])) ties++;
+  }
+
+  return (wins + ties / 2) / simulations;
+}
 
 export class AIBot {
   constructor(game, state, queue = { push: () => {} }, level = "easy") {
@@ -25,22 +59,28 @@ export class AIBot {
       return this.queue.push({ action: "fold" });
     }
 
-    const player = this.state.players[this.state.currentPlayer];
-    const cards = [...player.hand, ...this.state.community].map(toInternal);
-    const strength = evaluateHandPublic(cards).rankValue;
+    const winRate = estimateWinRate(
+      this.state,
+      this.state.currentPlayer,
+      this.level === "hard" ? 400 : 200
+    );
 
     if (this.level === "normal") {
-      if (strength >= 2 && bet)
-        return this.queue.push({ action: "bet", amount: Math.min(40, bet.max ?? 40) });
-      if (call && strength >= 1) return this.queue.push({ action: "call" });
+      if (bet && (winRate > 0.6 || (Math.random() < 0.1 && winRate > 0.3))) {
+        const amount = Math.min(bet.max, bet.min + Math.floor(bet.max * winRate));
+        return this.queue.push({ action: "bet", amount });
+      }
+      if (call && winRate > 0.4) return this.queue.push({ action: "call" });
       if (check) return this.queue.push({ action: "check" });
       return this.queue.push({ action: "fold" });
     }
 
     if (this.level === "hard") {
-      if (strength >= 3 && bet)
-        return this.queue.push({ action: "bet", amount: bet.max });
-      if (strength >= 1 && call) return this.queue.push({ action: "call" });
+      if (bet && (winRate > 0.7 || (Math.random() < 0.15 && winRate > 0.4))) {
+        const amount = bet.max;
+        return this.queue.push({ action: "bet", amount });
+      }
+      if (call && winRate > 0.5) return this.queue.push({ action: "call" });
       if (check) return this.queue.push({ action: "check" });
       return this.queue.push({ action: "fold" });
     }

--- a/src/core/models.js
+++ b/src/core/models.js
@@ -62,6 +62,20 @@ function countActive(players) {
   return players.filter((p) => !p.folded).length;
 }
 
+// Bagi pot ke pemenang secara merata.
+function distributePot(state) {
+  if (!state.winners || state.winners.length === 0) return;
+  const share = Math.floor(state.pot / state.winners.length);
+  const remainder = state.pot % state.winners.length;
+  state.winners.forEach((idx) => {
+    state.players[idx].chips += share;
+  });
+  if (remainder > 0) {
+    state.players[state.winners[0]].chips += remainder;
+  }
+  state.pot = 0;
+}
+
 // Super simpel evaluator: high card dari 7 kartu (placeholder, cukup untuk demo UI)
 
 export default class Game {
@@ -207,6 +221,7 @@ export default class Game {
       s.players.forEach((pl) => (pl.bet = 0));
       s.round = "Showdown";
       s.winners = this.checkWinners(s);
+      distributePot(s);
       s.endgame = true;
       return s;
     }
@@ -230,6 +245,7 @@ export default class Game {
       } else if (s.round === "River") {
         s.round = "Showdown";
         s.winners = this.checkWinners(s);
+        distributePot(s);
         s.endgame = true;
       }
     }


### PR DESCRIPTION
## Summary
- distribute pot to winners and maintain chip counts across hands
- add Monte Carlo hand simulations to AI for probability-based decisions
- improve betting behaviour per difficulty level

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abff7ccc84832289a5d9f0c9f80564