### PR TITLE
feat: add restart prompt when chips depleted

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import usePokerEngine from "./hooks/usePokerEngine";
 import PokerTable from "./components/PokerTable";
 import ActionBar from "./components/ActionBar";
 import WinnerModal from "./components/WinnerModal";
+import OutOfChipsModal from "./components/OutOfChipsModal";
 import useSound from "./hooks/useSound";
 
 export default function App() {
@@ -15,10 +16,11 @@ export default function App() {
     availableActions,
     handleAction: rawHandleAction,
     startNewHand,
+    resetGame,
   } = usePokerEngine([
     { name: "You", isBot: false },
     { name: "Lucy", isBot: true, level: "normal" },
-    { name: "Carl", isBot: true, level: "hard" },
+        { name: "Carl", isBot: true, level: "hard" },
   ]);
 
   // Menggunakan suara yang sama untuk semua aksi
@@ -91,6 +93,13 @@ export default function App() {
           <WinnerModal
             winners={winners.map((i) => state.players[i].name)}
             onRestart={startNewHand}
+          />
+        )}
+
+        {state.players[0].chips <= 0 && (
+          <OutOfChipsModal
+            onRestart={resetGame}
+            onExit={() => (window.location.href = "/")}
           />
         )}
       </div>

--- a/src/components/OutOfChipsModal.js
+++ b/src/components/OutOfChipsModal.js
@@ -1,0 +1,26 @@
+import React from "react";
+
+export default function OutOfChipsModal({ onRestart, onExit }) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-60 z-50">
+      <div className="bg-white text-black rounded-lg p-6 shadow-xl w-96 text-center">
+        <h2 className="text-2xl font-bold mb-4">Saldo chip Anda habis</h2>
+        <p className="mb-4">Apakah Anda ingin memulai permainan dari awal?</p>
+        <div className="flex justify-center gap-4">
+          <button
+            onClick={onRestart}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+          >
+            Mulai Ulang
+          </button>
+          <button
+            onClick={onExit}
+            className="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700"
+          >
+            Keluar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/usePokerEngine.js
+++ b/src/hooks/usePokerEngine.js
@@ -54,6 +54,10 @@ export default function usePokerEngine(initialPlayers) {
     setState((prev) => game.start(prev));
   }, [game]);
 
+  const resetGame = useCallback(() => {
+    setState(() => game.start());
+  }, [game]);
+
   return {
     state,
     pot,
@@ -62,5 +66,6 @@ export default function usePokerEngine(initialPlayers) {
     availableActions,
     handleAction,
     startNewHand,
+    resetGame,
   };
 }


### PR DESCRIPTION
## Summary
- add OutOfChipsModal to prompt restart or exit when player chips reach zero
- expose `resetGame` in poker engine and show modal from App

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ac047120948322b536b1cd73af223e